### PR TITLE
Modify the default value for k=0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 NicsTr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/website/primes/management/commands/generate_prime.py
+++ b/website/primes/management/commands/generate_prime.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 is_probably_prime = True
     
         if k == 0:
-            proba = 50
+            proba = 23.98
         else:
             proba = round((1-0.25**k)*100, 2)
         seed(n)


### PR DESCRIPTION
There is 9592 primes between 0 and 100000.
The process generate a number n between 2 and 100000 requiring that it is not a multiple of 2 or 5.
So there are 40000 different possible n values (they all have the same probability to appear) and between those only 9590 are primes.
This way, when k=0 (no computation on whether or not the number is prime), there is a probability of 0.23975 that the number generated is prime.

Also, adding a license.